### PR TITLE
new v

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,3 +1,3 @@
 rauth==0.7.3
 requests==2.18.3
-xmltodict==0.11.0
+xmltodict==0.12.0


### PR DESCRIPTION
Using python 3.7.4:
```
ERROR: Could not find a version that satisfies the requirement xmltodict==0.11.0 (from goodreads_api_client) (from versions: 0.12.0)
ERROR: No matching distribution found for xmltodict==0.11.0 (from goodreads_api_client)
```
Not supported with xmltodict v0.11.0 - https://pypi.org/project/xmltodict/0.11.0/
Supported in v.0.12.0 - https://pypi.org/project/xmltodict/0.12.0/

